### PR TITLE
Update card_view_media.py

### DIFF
--- a/src/card_view_media.py
+++ b/src/card_view_media.py
@@ -97,9 +97,8 @@ class MediaCardView(CardView):
             EDIT_TOOLTIPS["Media"],
             DELETE_TOOLTIPS["Media"],
         ),
-        TOOLBAR_MOREBUTTONS,
         """
-        <placeholder id='AfterTools'>
+        <placeholder id='MoreButtons'>
           <child>
             <object class="GtkToolButton">
               <property name="icon-name">gramps-viewmedia</property>
@@ -107,6 +106,38 @@ class MediaCardView(CardView):
               <property name="tooltip_text" translatable="yes">"""
         """View in the default viewer</property>
               <property name="label" translatable="yes">View</property>
+            </object>
+            <packing>
+              <property name="homogeneous">False</property>
+            </packing>
+          </child>
+          <child>
+		    <object class="GtkSeparatorToolItem" id="sep2"/>
+          </child>
+		  <child>
+            <object class="GtkToolButton">
+              <property name="icon-name">help-browser</property>
+              <property name="action-name">win.ViewHelp</property>
+              <property name="tooltip_text" translatable="yes">"""
+        """Card View help</property>
+              <property name="label" translatable="yes">Help</property>
+              <property name="use-underline">True</property>
+            </object>
+            <packing>
+              <property name="homogeneous">False</property>
+            </packing>
+          </child>
+          <child>
+		    <object class="GtkSeparatorToolItem" id="sep3"/>
+          </child>
+		  <child>
+            <object class="GtkToolButton">
+              <property name="icon-name">edit-copy</property>
+              <property name="action-name">win.OpenPinnedView</property>
+              <property name="tooltip_text" translatable="yes">"""
+        """Pin copy of current view in new window</property>
+              <property name="label" translatable="yes">Pin</property>
+              <property name="use-underline">True</property>
             </object>
             <packing>
               <property name="homogeneous">False</property>


### PR DESCRIPTION
This gets all icons into the menu. Although the Open Media icon remains inactive (??). Issue 222.

I had added an Edit Filter icon to the various views for my tool bars. I had a hard time getting the extra Media icon to display with my Filter icon., Had to make them all under the MoreButton.

Of course, I have not tested any of this without my PR1319 installed.

![newmediatoolbar](https://user-images.githubusercontent.com/61884146/197848979-f6863581-1d9d-44e6-91f2-33d23a6045b4.png)
